### PR TITLE
Add motor_forms table to down migration

### DIFF
--- a/lib/generators/motor/templates/install.rb
+++ b/lib/generators/motor/templates/install.rb
@@ -149,6 +149,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
     drop_table :motor_audits
     drop_table :motor_alert_locks
     drop_table :motor_alerts
+    drop_table :motor_forms
     drop_table :motor_taggable_tags
     drop_table :motor_tags
     drop_table :motor_resources


### PR DESCRIPTION
Hi there,

I noticed during a rollback & migration that this table was missing, which causes issues if the migration is `rake db:rollback`-ed & migration retried