### PR TITLE
Add Spanish translations

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,163 +1,162 @@
 es:
   motor:
-    action_has_been_applied: Action has been applied!
-    action_has_failed_with_code: Action failed with code
-    action_type: Action type
-    actions: Actions
-    add: Add
-    add_action: Add Action
-    add_alert: Add Alert
-    add_column: Add Column
-    add_dashboard: Add Dashboard
-    add_field: Add Field
-    add_filter: Add Filter
-    add_form: Add Form
-    add_group: Add Group
-    add_item: Add Item
-    add_link: Add Link
-    add_query: Add Query
-    add_scope: Add Scope
-    add_tab: Add Tab
-    alert_email_has_been_sent: Alert email has been sent!
-    alert_has_been_activated: Alert has been activated
-    alert_has_been_disabled: Alert has been disabled
-    alert_has_been_saved: Alert has been saved!
-    alert_name: Alert name
-    all_resources: All Resources
-    and: And
-    api_path: API path
-    apply: Apply
-    are_you_sure: Are you sure?
-    associations: Associations
-    bar_chart: Bar chart
+    action_has_been_applied: ¡Acción aplicada!
+    action_has_failed_with_code: La acción falló con código
+    action_type: Tipo de acción
+    actions: Acciones
+    add: Añadir
+    add_action: Añadir Acción
+    add_alert: Añadir Alerta
+    add_column: Añadir Columna
+    add_dashboard: Añadir Dashboard
+    add_field: Añadir Campo
+    add_filter: Añadir Filtro
+    add_form: Añadir Formulario
+    add_group: Añadir Grupo
+    add_item: Añadir Elemento
+    add_link: Añadir Link
+    add_query: Añadir Consulta
+    add_scope: Añadir Alcance
+    add_tab: Añadir Pestaña
+    alert_email_has_been_sent: ¡Email de alerta enviado!
+    alert_has_been_activated: Alerta activada
+    alert_has_been_disabled: Alerta desactivada
+    alert_has_been_saved: ¡Alerta guardada!
+    alert_name: Nombre de la alerta
+    all_resources: Todos los Recursos
+    and: Y
+    api_path: Dirección en API
+    apply: Aplicar
+    are_you_sure: ¿Estás seguro?
+    associations: Asociaciones
+    bar_chart: Gráfico de barras
     base: Base
-    cancel: Cancel
-    clear_all: Clear All
-    clear_selection: Clear selection
-    close: Close
-    close_editor: Close editor
-    close_settings: Close Settings
-    close_variables: Close Variables
-    columns: Columns
-    create: Create
-    currency: Currency
-    dashboard_has_been_saved: Dashboard has been saved!
-    dashboard_title: Dashboard title
+    cancel: Cancelar
+    clear_all: Quitar todos
+    clear_selection: Quitar selección
+    close: Cerrar
+    close_editor: Cerrar editor
+    close_settings: Cerrar Configuración
+    close_variables: Cerrar Variables
+    columns: Columnas
+    create: Crear
+    currency: Moneda
+    dashboard_has_been_saved: ¡Dashboard guardado!
+    dashboard_title: Título del dashboard
     decimal: Decimal
-    default_value: Default value
-    describe_this_alert_optional: Describe this alert (optional)
-    describe_your_dashboard_optional: Describe your dashboard (optional)
-    describe_your_form_optional: Describe your form (optional)
-    describe_your_query_optional: Describe your query (optional)
-    description: Description
-    deselect_all: Deselect All
-    disable: Disable
-    display_as: Display as
-    edit: Edit
-    edit_sql: Edit SQL
+    default_value: Valor por defecto
+    describe_this_alert_optional: Describe esta alerta (opcional)
+    describe_your_dashboard_optional: Describe tu dashboard (opcional)
+    describe_your_form_optional: Describe tu formulario (opcional)
+    describe_your_query_optional: Describe tu consulta (opcional)
+    description: Descripción
+    deselect_all: Deseleccionar todo
+    disable: Desactivar
+    display_as: Mostrar como
+    edit: Editar
+    edit_sql: Editar SQL
     emails: Emails
-    every_day_at_hh_mm: every day at HH:mm PM...
-    field_name: Field name
-    filters: Filters
-    form: Form
-    form_has_been_saved: Form has been saved!
-    form_has_been_submitted_successfully: Form has been submitted successfully!
-    form_name: Form name
-    forms: Forms
-    funnel: Funnel
-    group_name: Group name
-    has_been_created: has been created
-    has_been_removed_succesfully: has been removed succesfully
-    has_been_updated: has been updated
-    hello_admin: Hello Admin 👋
-    input_type: Input type
-    interval: Interval
-    items_has_been_removed: items has been removed
-    label: Currency
-    line_chart: Line chart
-    link_name: Link name
+    every_day_at_hh_mm: todos los días a las HH:mm PM...
+    field_name: Nombre del campo
+    filters: Filtros
+    form: Formulario
+    form_has_been_saved: ¡Formulario guardado!
+    form_has_been_submitted_successfully: ¡Formulario enviado con éxito!
+    form_name: Nombre del formulario
+    forms: Formularios
+    funnel: Embudo
+    group_name: Nombre del grupo
+    has_been_created: creado
+    has_been_removed_succesfully: eliminado con éxito
+    has_been_updated: actualizado
+    hello_admin: Hola Admin 👋
+    input_type: Tipo de campo
+    interval: Intervalo
+    items_has_been_removed: elementos fueron eliminados
+    label: Moneda
+    line_chart: Gráfico de líneas
+    link_name: Nombre del link
     links: Links
-    load_initial_data: Load initial data
-    loading: Loading...
-    looks_like_you_are_new_here: Looks like you are new here 🙃
+    load_initial_data: Cargar datos iniciales
+    loading: Cargando...
+    looks_like_you_are_new_here: Parece que eres nuevo aquí 🙃
     markdown: Markdown
-    method: Method
-    multiple: Multiple
-    name: Name
-    new_alert: New alert
-    new_dashboard: New dashboard
-    new_form: New form
-    new_query: New query
-    no_data: No data
-    not_found: Not Found
+    method: Método
+    multiple: Múltiple
+    name: Nombre
+    new_alert: Nueva alerta
+    new_dashboard: Nuevo dashboard
+    new_form: Nuevo formulario
+    new_query: Nueva consulta
+    no_data: Sin datos
+    not_found: Sin resultados
     ok: OK
-    options_separated_with_new_line_or_comma: Options separated with new line or comma
-    param_name: Param name
-    path: Path
-    percent: Percent
-    pie_chart: Pie chart
-    query: Query
-    query_has_been_saved: Query has been saved!
-    query_name: Query name
-    query_not_selected: Query not selected
-    query_revisions: Query Revisions
-    reference: Reference
-    reference_resource: Reference resource
-    remove: Remove
-    reports: Reports
-    request_param: Request param
-    resources: Resources
-    resubmit: Resubmit
-    revert: Revert
-    revision_has_been_applied: Revision has been applied
-    revisions: Revisions
-    row_chart: Row chart
-    save: Save
-    save_and_create_new: Save and Create New
-    save_as_new: Save as new
-    save_dashboard: Save dashboard
-    save_form: Save form
-    save_query: Save query
-    scopes: Scopes
-    search: Search
-    search_placeholder: Search...
-    select_alert_tags: Select alert tags
-    select_dashboard: Select dashboard
-    select_dashboard_tags: Select dashboard tags
-    select_form: Select form
-    select_form_tags: Select dashform tags
-    select_options: Select options
-    select_placeholder: Select...
-    select_query: Select query
-    select_query_tags: Select query tags
-    select_resource_placeholder: Select resource...
-    select_resource_placeholder: Select resource...
-    selected_item_has_been_removed: Selected item has been removed
-    selected_item_will_be_removed_are_you_sure: Selected item will be removed. Are you sure?
-    send_empty: Send empty?
-    send_now: Send Now
-    send_to: Send to
-    set_tags: Set tags
-    settings: Settings
-    stacked_bars: Stacked bars
-    submit: Submit
-    tab_type: Tab type
-    table: Table
-    tabs: Tabs
-    tags: Tags
-    timezone: Timezone
-    title: Title
-    type: Type
-    unable_to_load_form_data: Unable to load form data
-    unable_to_remove_item: Unable to remove item
-    unable_to_remove_items: Unable to remove items
-    unable_to_send_email: Unable to send email
-    unable_to_submit_form: Unable to submit form
-    value: Value
-    values_axis: Values axis
+    options_separated_with_new_line_or_comma: Las opciones van separadas con una nueva línea o una coma
+    param_name: Nombre del parámetro
+    path: Dirección
+    percent: Porcentaje
+    pie_chart: Gráfico circular
+    query: Consulta
+    query_has_been_saved: ¡Consulta guardada!
+    query_name: Nombre de la consulta
+    query_not_selected: Consulta no seleccionada
+    query_revisions: Revisiones de la consulta
+    reference: Referencia
+    reference_resource: Recurso de referencia
+    remove: Eliminar
+    reports: Reportes
+    request_param: Parametro de request
+    resources: Recursos
+    resubmit: Reenviar
+    revert: Revertir
+    revision_has_been_applied: Revisión aplicada
+    revisions: Revisiones
+    row_chart: Gráfico de filas
+    save: Guardar
+    save_and_create_new: Guardar y crear otro
+    save_as_new: Guardar como nuevo
+    save_dashboard: Guardar dashboard
+    save_form: Guardar formulario
+    save_query: Guardar consulta
+    scopes: Alcances
+    search: Buscar
+    search_placeholder: Buscar...
+    select_alert_tags: Seleccionar etiquetas de alerta
+    select_dashboard: Seleccionar dashboard
+    select_dashboard_tags: Seleccionar tags de dashboard
+    select_form: Seleccionar formulario
+    select_form_tags: Select tags de formulario
+    select_options: Seleccionar opciones
+    select_placeholder: Seleccionar...
+    select_query: Seleccionar consulta
+    select_query_tags: Seleccionar etiquetas de consulta
+    select_resource_placeholder: Seleccionar recurso...
+    selected_item_has_been_removed: El elemento seleccionado fue eliminado
+    selected_item_will_be_removed_are_you_sure: El elemento seleccionado será eliminado. ¿Estás seguro?
+    send_empty: ¿Enviar sin contenido?
+    send_now: Enviar ahora
+    send_to: Enviar a
+    set_tags: Seleccionar etiquetas
+    settings: Configuración
+    stacked_bars: Barras apiladas
+    submit: Enviar
+    tab_type: Tipo de pestaña
+    table: Tabla
+    tabs: Pestañas
+    tags: Etiquetas
+    timezone: Zona horaria
+    title: Título
+    type: Tipo
+    unable_to_load_form_data: No se pudieron cargar los datos del formulario
+    unable_to_remove_item: No se pudo eliminar el elemento
+    unable_to_remove_items: No se pudieron eliminar los elementos
+    unable_to_send_email: No se pudo enviar el email
+    unable_to_submit_form: No se pudo enviar el formulario
+    value: Valor
+    values_axis: Eje de valores
     variables: Variables
-    visibility: Visibility
-    visualization: Visualization
+    visibility: Visibilidad
+    visualization: Visualización
     i:
       locale: es
       select:


### PR DESCRIPTION
This PR adds Spanish translations to Motor Admin.

## Missing translations

Some texts do not have i18n support, so I couldn't translate them. I'll leave some pictures below to point them out:

### Reports page: title and tabs

The title and the tabs in the reports page are missing i18n support:

![1](https://user-images.githubusercontent.com/65265704/123154028-c1d4b100-d43c-11eb-90d8-0d1187eccb67.png)

### Custom form builder

Translations are missing for the form errors and the input types (don't know if they can be translatable):

![custom form builder 1](https://user-images.githubusercontent.com/65265704/123154089-d0bb6380-d43c-11eb-93ce-10abefb76671.png)

Also, in the `Add field` form, translations are missing for the `Required` and `Multiple` checkboxes, and the `Add` button:

![custom form builder 2](https://user-images.githubusercontent.com/65265704/123154116-d7e27180-d43c-11eb-93e9-8f9e875de28a.png)

### Filters

The title of the drawer is supported on i18n, but the order of the words is incorrect for Spanish, and I presume the same would happen in other languages.

Correct translation for `${resource_name} filters` should be `Filtros de ${resource_name}`.

I'm not sure if this can be done, since I'm guessing the translations are being passed from the Rails app to a global variable, so using string interpolation in i18n might be off the table:

![filters](https://user-images.githubusercontent.com/65265704/123154361-1d9f3a00-d43d-11eb-8036-53d4a8526b34.png)

### Settings

The title in the settings drawer is missing i18n support:

![settings drawer](https://user-images.githubusercontent.com/65265704/123154870-c8175d00-d43d-11eb-92cc-5602a198d519.png)

### Resource settings

The title in the resource settings drawer is missing i18n support, should be `Configuración de ${resource_name}`

Also, when editing actions, the action type options don't have i18n support, as well as the default action names:

![settings drawer 2png](https://user-images.githubusercontent.com/65265704/123154874-c9e12080-d43d-11eb-9895-41f7c74f31db.png)

### Intelligence search

The `Search...` placeholder is missing i18n support:

![smart search](https://user-images.githubusercontent.com/65265704/123155182-2cd2b780-d43e-11eb-8068-67ed26cfd557.png)

## Bugs

I found only one bug. In the `Create Alert` form, the select tags field placeholder doesn't show completely:

![new_alert_form_placeholder_bug](https://user-images.githubusercontent.com/65265704/123154848-c2ba1280-d43d-11eb-90ef-5e1e6dc5d602.png)


