### PR TITLE
fix(activestorage): Allows configurable service on attachment

### DIFF
--- a/lib/motor/active_record_utils/active_storage_blob_patch.rb
+++ b/lib/motor/active_record_utils/active_storage_blob_patch.rb
@@ -3,7 +3,8 @@
 module Motor
   module ActiveRecordUtils
     module ActiveStorageBlobPatch
-      KEYWORD_ARGS = %i[io filename content_type metadata identify].freeze
+      KEYWORD_ARGS =
+        %i[io filename content_type metadata service_name identify record].freeze
 
       def build_after_upload(hash)
         super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -3,7 +3,7 @@
 class Product < ApplicationRecord
   CATEGORIES = %w[fanfiction humor mythology fantasy].freeze
 
-  has_one_attached :image
+  has_one_attached :image, service: :product_assets
 
   has_many :line_items, dependent: :destroy
   has_many :orders, through: :line_items, dependent: :destroy

--- a/spec/dummy/config/storage.yml
+++ b/spec/dummy/config/storage.yml
@@ -6,13 +6,16 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+product_assets:
+  service: Disk
+  root: <%= Rails.root.join("storage/product_assets") %>
+
 amazon:
   service: S3
   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['AWS_REGION'] %>
   bucket: <%= ENV['S3_ATTACHMENTS_BUCKET'] %>
-
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS

--- a/spec/dummy/config/storage.yml
+++ b/spec/dummy/config/storage.yml
@@ -7,8 +7,16 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 product_assets:
+<% Rails.env.production? %>
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['AWS_REGION'] %>
+  bucket: <%= ENV['S3_ATTACHMENTS_BUCKET'] %>
+<% else %>
   service: Disk
   root: <%= Rails.root.join("storage/product_assets") %>
+<% end %>
 
 amazon:
   service: S3
@@ -16,6 +24,7 @@ amazon:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['AWS_REGION'] %>
   bucket: <%= ENV['S3_ATTACHMENTS_BUCKET'] %>
+  
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS


### PR DESCRIPTION
* Fixes issue where attachment is always saved to the globally configured service

This fix allows an attachment with a configured service to upload to the given service. Before the patch was preventing necessary keys from being passed on to `build_after_unfurling` in my case.

Here is the PR on Rails for this feature: https://github.com/rails/rails/pull/34935